### PR TITLE
fix: compatibility with Modern Industrialization 2.5.1+

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,17 +28,17 @@ mod_github=https://github.com/WhitePhant0m/Industrialization-Overdrive
 mod_credits=Big thanks to Swedz for his mods, TesseractAPI and Extended-Industrialization, wouldn't have been able to make this otherwise.
 
 # Dependencies
-modern_industrialization_version=2.4.2
-modern_industrialization_version_range=[2.4.2, 2.5-]
-guideme_version=21.1.15
+modern_industrialization_version=2.5.1
+modern_industrialization_version_range=[2.4.2, 2.6-)
+guideme_version=21.1.16
 guideme_version_range=[21.1.5, 22-)
 grandpower_version=3.0.0
 cloth_config_version=15.0.127
 emi_version=1.1.22
-tesseract_version=1.12.0
+tesseract_version=1.12.5
 tesseract_version_range=[1.12.0, 1.13-)
 mi_tweaks_version=1.8.18
-extended_industrialization_version=1.15.22
+extended_industrialization_version=1.15.44
 extended_industrialization_version_range=[1.10.0-beta-,)
 ae2_version=19.2.17
 kubejs_version=2101.7.2-build.336

--- a/src/main/java/dev/wp/industrialization_overdrive/machines/guicomponents/multiprocessingarraymachineslot/MultiProcessingArrayMachineSlotClient.java
+++ b/src/main/java/dev/wp/industrialization_overdrive/machines/guicomponents/multiprocessingarraymachineslot/MultiProcessingArrayMachineSlotClient.java
@@ -82,10 +82,12 @@ public class MultiProcessingArrayMachineSlotClient extends GuiComponentClient<Un
             }
 
             @Override
-            public void renderTooltip(MachineScreen screen, Font font, GuiGraphics graphics, int x, int y, int cursorX, int cursorY) {
+            public boolean renderTooltip(MachineScreen screen, Font font, GuiGraphics graphics, int x, int y, int cursorX, int cursorY) {
                 if (screen.getFocusedSlot() instanceof SlotTooltip st && !screen.getFocusedSlot().hasItem()) {
                     graphics.renderTooltip(font, st.getTooltip(), cursorX, cursorY);
+                    return true;
                 }
+                return false;
             }
         };
     }


### PR DESCRIPTION
- Expand MI version range from [2.4.2, 2.5-] to [2.4.2, 2.6-) to support MI 2.5.x releases (2.5.1 was previously excluded because the 2.5- suffix only matches pre-release builds, not full releases)
- Fix ClientComponentRenderer.renderTooltip() return type: changed from void to boolean to match the updated MI 2.5.1 API (return true when a tooltip was rendered, false otherwise)
- Bump dependency versions to latest releases:
  - modern_industrialization: 2.4.2 -> 2.5.1
  - tesseract: 1.12.0 -> 1.12.5
  - guideme: 21.1.15 -> 21.1.16
  - extended_industrialization: 1.15.22 -> 1.15.44